### PR TITLE
Fix install_linux.sh script url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ with a fresh install of Ubuntu 20.04.
 You can install the new CLI using the install script:
 
 ```console
-curl -L https://github.com/docker/aci-integration-beta/blob/main/scripts/install_linux.sh | sh
+curl -L https://raw.githubusercontent.com/docker/aci-integration-beta/main/scripts/install_linux.sh | sh
 ```
 
 ### Manual install


### PR DESCRIPTION
Could use either https://raw.githubusercontent.com/docker/aci-integration-beta/main/scripts/install_linux.sh or https://github.com/docker/aci-integration-beta/blob/main/scripts/install_linux.sh?raw=true that redirect to the first one..